### PR TITLE
Build fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_CXX_STANDARD 14)
 
 find_package(JNI REQUIRED)
 
-include_directories(${JNI_INCLUDE_DIRS})
+include_directories(${JNI_INCLUDE_DIRS} libfvad/include)
 
 set(SOURCE_FILES
     src/native/org_jitsi_webrtcvadwrapper_WebRTCVad.cpp
@@ -13,5 +13,5 @@ set(SOURCE_FILES
 
 add_library(webrtcvadwrapper SHARED ${SOURCE_FILES})
 
-find_library(FVAD_LIB fvad)
+find_library(FVAD_LIB fvad lib/native/linux-64)
 target_link_libraries(webrtcvadwrapper ${FVAD_LIB})

--- a/compile_libfvad.sh
+++ b/compile_libfvad.sh
@@ -7,7 +7,7 @@ TARGET="$SCRIPTPATH/target_libfvad/"
 cd $SCRIPTPATH
 
 if  [ ! -d "libfvad" ]; then
-    git clone git@github.com:dpirch/libfvad.git
+    git clone https://github.com/dpirch/libfvad.git
 fi
 
 cd libfvad
@@ -17,6 +17,7 @@ make
 make install
 
 cd ..
+mkdir -p lib/native/linux-64
 cp "$TARGET/lib/libfvad.so.0.0.0" lib/native/linux-64
 mv lib/native/linux-64/libfvad.so.0.0.0 lib/native/linux-64/libfvad.so
 

--- a/compile_libwebrtcvadwrapper.sh
+++ b/compile_libwebrtcvadwrapper.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-mkdir -p cmake-build
+mkdir -p cmake-build lib/native/linux-64
 
 cd cmake-build
 cmake ../


### PR DESCRIPTION
- configure webrtcvadwrapper build to find the built libfvad library and checked-out libfvad source tree (for headers) automatically
- check out libfvad using an anonymous git clone
- don't assume the target dir already exists